### PR TITLE
feat: Add CI/CD pipeline using GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    - name: Run tests
+      run: |
+        python -m unittest test_sbg.py

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # GitLab Group Cloner & Updater
 
+[![CI](https://github.com/YOUR_USERNAME_OR_ORG/YOUR_REPO_NAME/actions/workflows/ci.yml/badge.svg)](https://github.com/YOUR_USERNAME_OR_ORG/YOUR_REPO_NAME/actions/workflows/ci.yml)
+
 A command-line Python tool to **clone** or **update** (_pull_) **all** GitLab repositories under one or more groups (including nested subgroups), organizing them into a mirror directory tree that matches each project’s namespace.
 
 ---


### PR DESCRIPTION
This commit introduces a GitHub Actions workflow for Continuous Integration.

The workflow (`.github/workflows/ci.yml`):
- Triggers on push or pull request to the `master` branch.
- Runs jobs on `ubuntu-latest`.
- Tests across a matrix of Python versions: 3.9, 3.10, 3.11, 3.12, and 3.13.
- Includes steps to:
    - Checkout repository code.
    - Set up the specified Python version.
    - Install dependencies from `requirements.txt`.
    - Run unit tests using `python -m unittest test_sbg.py`.

A status badge for this CI workflow has also been added to `README.md`. You will need to replace the placeholder owner and repository name in the badge URL for it to function correctly.