### PR TITLE
Refactor: Migrate from print statements to Python's logging module

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,12 @@ python sbg.py \
 
 ---
 
+## Logging
+
+The script uses Python's standard `logging` module for all console output. This provides users with more control over verbosity and output destinations (e.g., logging to a file). By default, it logs messages at the `INFO` level and above to standard output.
+
+---
+
 ## Script Reference
 
 ```text

--- a/sbg.py
+++ b/sbg.py
@@ -71,7 +71,7 @@ class GitLabCloner:
                 projs = self.list_projects(gid)
                 subs  = self.list_subgroups(gid)
             except requests.HTTPError as error:
-                logger.warning(f"Could not fetch for group {gid}: {error}")
+                logger.warning("Could not fetch for group %s: %s", gid, error)
                 continue
             projects.extend(projs)
             for sg in subs:
@@ -82,17 +82,17 @@ class GitLabCloner:
     def clone_or_pull(repo_url, target_path):
         """Clone if missing, or pull if already a Git repo."""
         if os.path.isdir(target_path) and os.path.isdir(os.path.join(target_path, ".git")):
-            logger.info(f"Updating existing repo at {target_path}")
+            logger.info("Updating existing repo at %s", target_path)
             try:
                 subprocess.check_call(["git", "-C", target_path, "pull"])
             except subprocess.CalledProcessError as error:
-                logger.error(f"Pull failed for {target_path}: {error}")
+                logger.error("Pull failed for %s: %s", target_path, error)
         else:
-            logger.info(f"Cloning into {target_path}")
+            logger.info("Cloning into %s", target_path)
             try:
                 subprocess.check_call(["git", "clone", repo_url, target_path])
             except subprocess.CalledProcessError as error:
-                logger.error(f"Clone failed for {repo_url} into {target_path}: {error}")
+                logger.error("Clone failed for %s into %s: %s", repo_url, target_path, error)
 
 def main():
     logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s', force=True)
@@ -102,10 +102,10 @@ def main():
     # 1) Gather & dedupe all projects
     all_projects = {}
     for gid in args.group_ids:
-        logger.info(f"Fetching projects under group '{gid}' …")
+        logger.info("Fetching projects under group '%s' …", gid)
         for proj in cloner.gather_all_projects(gid):
             all_projects[proj["id"]] = proj
-    logger.info(f"Total unique projects to process: {len(all_projects)}")
+    logger.info("Total unique projects to process: %s", len(all_projects))
 
     # 2) Ensure destination root exists
     dest_root = os.path.abspath(args.dest)
@@ -133,5 +133,5 @@ if __name__ == "__main__":
         logger.info("Aborted by user")
         sys.exit(0)
     except Exception as e:
-        logger.critical(f"Fatal error: {e}")
+        logger.critical("Fatal error: %s", e)
         sys.exit(1)


### PR DESCRIPTION
This commit replaces all instances of `print()` with calls to Python's standard `logging` module.

Key changes:
- Configured a logger in `sbg.py` with a standard format and INFO level.
- Replaced informational, warning, and error `print()` calls with `logger.info()`, `logger.warning()`, and `logger.error()` respectively.
- Handled `sys.exit()` calls to log critical errors or informational messages (like user abortion) before exiting.
- Updated unit tests in `test_sbg.py` to use `self.assertLogs` for capturing and verifying log output, ensuring continued test coverage.
- Added a note to `README.md` about the use of the logging module.

This change provides more structured and configurable logging, allowing you to control log verbosity and output destinations (e.g., file output) if needed in the future.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a "Logging" section to the README, explaining how console output is managed and how users can control logging behavior.

- **Refactor**
  - Replaced all direct print statements with standardized logging for informational, warning, and error messages.
  - Updated error handling to use logging for user aborts and fatal exceptions.

- **Tests**
  - Updated tests to use logging capture instead of manual output redirection for verifying warning and error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->